### PR TITLE
`SequentialModuleList`クラスを追加しました。

### DIFF
--- a/src/utils/model.py
+++ b/src/utils/model.py
@@ -1,0 +1,13 @@
+"""This file contains utility tools for building models."""
+import torch
+import torch.nn as nn
+
+
+class SequentialModuleList(nn.ModuleList):
+    """Construct dnn modules like `nn.ModuleList`, and forward data like
+    `nn.Sequential`."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for layer in self:
+            x = layer(x)
+        return x

--- a/tests/utils/test_model.py
+++ b/tests/utils/test_model.py
@@ -1,0 +1,9 @@
+import torch
+import torch.nn as nn
+
+from src.utils.model import SequentialModuleList
+
+
+def test_SequentialModuleList():
+    mod = SequentialModuleList([nn.Linear(2, 2) for _ in range(3)])
+    mod(torch.randn(2))


### PR DESCRIPTION
## 概要

`nn.ModuleList`を`nn.Sequential`のように扱うためのクラスです。
`hydra`によるInstantiateの時に、`func(*args)` に直接値を渡すことができなかったためです。もしやる方法があれば教えてください。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make test`コマンドでローカルにテストしましたか?
- [x] `make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
