### PR TITLE
Agentが学習するデモスクリプトの作成

### DIFF
--- a/.project-root
+++ b/.project-root
@@ -1,0 +1,2 @@
+# this file is required for inferring the project root directory
+# do not delete

--- a/configs/agent/curiosity_ppo_agent.yaml
+++ b/configs/agent/curiosity_ppo_agent.yaml
@@ -1,0 +1,13 @@
+_target_: src.agents.curiosity_ppo_agent.CuriosityPPOAgent
+_partial_: true
+
+reward:
+  _target_: src.models.components.reward.curiosity_reward.CuriosityReward
+
+sleep_action:
+  _target_: src.environment.actuators.locomotion_actuator.get_sleep_action
+
+device: "cuda:0"
+dtype:
+  _target_: hydra.utils.get_object
+  path: "torch.float32"

--- a/configs/data_collector/dict_dynamics_trajectory.yaml
+++ b/configs/data_collector/dict_dynamics_trajectory.yaml
@@ -1,0 +1,11 @@
+_target_: src.data_collectors.aggregations.dict_data_collectors.DictDataCollectors
+
+dynamics:
+  _target_: src.data_collectors.dynamics_data_collector.DynamicsDataCollector
+  max_size: 2048
+
+trajectory:
+  _target_: src.data_collectors.trajectory_data_collector.TrajectoryDataCollector
+  max_size: ${interaction.num_steps}
+  gamma: 0.99 # from large-scale-curiosity
+  gae_lambda: 0.95 # from large-scale-curiosity

--- a/configs/demo.yaml
+++ b/configs/demo.yaml
@@ -1,0 +1,19 @@
+# @package _global_
+
+# specify here default configuration
+# order of defaults determines the order in which configs override each other
+defaults:
+  - _self_
+  - model: inverse_forward_ppo
+  - data_collector: dict_dynamics_trajectory
+  - trainers_builder: inverse_forward_ppo
+  - agent: curiosity_ppo_agent
+  - environment: frame_locomotion_sleep
+  - interaction: fixed_step
+
+  - paths: default
+  - hydra: default
+
+task_name: "demo"
+
+seed: null

--- a/configs/environment/frame_locomotion_sleep.yaml
+++ b/configs/environment/frame_locomotion_sleep.yaml
@@ -1,0 +1,20 @@
+_target_: src.environment.periodic_environment.PeriodicEnvironment
+
+sensor:
+  _target: src.utils.environment.create_frame_sensor
+  camera_index: 0
+  width: 256
+  height: 256
+  base_fps: 60
+
+actuator:
+  _target_: src.utils.environment.create_locomotion_actuator
+  osc_address: "127.0.0.1"
+
+adjustor:
+  _target_: src.environment.interval_adjustors.sleep_interval_adjustor.SleepIntervalAdjustor
+  interval: 0.1 # 10 fps
+
+
+
+

--- a/configs/environment/frame_locomotion_sleep.yaml
+++ b/configs/environment/frame_locomotion_sleep.yaml
@@ -1,7 +1,7 @@
 _target_: src.environment.periodic_environment.PeriodicEnvironment
 
 sensor:
-  _target: src.utils.environment.create_frame_sensor
+  _target_: src.utils.environment.create_frame_sensor
   camera_index: 0
   width: 256
   height: 256

--- a/configs/environment/frame_locomotion_sleep.yaml
+++ b/configs/environment/frame_locomotion_sleep.yaml
@@ -14,7 +14,3 @@ actuator:
 adjustor:
   _target_: src.environment.interval_adjustors.sleep_interval_adjustor.SleepIntervalAdjustor
   interval: 0.1 # 10 fps
-
-
-
-

--- a/configs/hydra/default.yaml
+++ b/configs/hydra/default.yaml
@@ -1,0 +1,21 @@
+# https://github.com/ashleve/lightning-hydra-template/blob/main/configs/hydra/default.yaml
+
+# https://hydra.cc/docs/configure_hydra/intro/
+
+# enable color logging
+defaults:
+  - override hydra_logging: colorlog
+  - override job_logging: colorlog
+
+# output directory, generated dynamically on each run
+run:
+  dir: ${paths.log_dir}/${task_name}/runs/${now:%Y-%m-%d}_${now:%H-%M-%S}
+sweep:
+  dir: ${paths.log_dir}/${task_name}/multiruns/${now:%Y-%m-%d}_${now:%H-%M-%S}
+  subdir: ${hydra.job.num}
+
+job_logging:
+  handlers:
+    file:
+      # Incorporates fix from https://github.com/facebookresearch/hydra/pull/2242
+      filename: ${hydra.runtime.output_dir}/${task_name}.log

--- a/configs/interaction/fixed_step.yaml
+++ b/configs/interaction/fixed_step.yaml
@@ -1,0 +1,3 @@
+_target_: src.interactions.fixed_step_interaction.FixedStepInteraction
+_partial_: true
+num_steps: 128 # from large-scale-curiosity

--- a/configs/model/inverse_forward_ppo.yaml
+++ b/configs/model/inverse_forward_ppo.yaml
@@ -21,12 +21,47 @@ inverse_dynamics:
   optimizer:
     _target_: torch.optim.Adam
     _partial_: true
-    lr: 1e-4 # https://github.com/openai/large-scale-curiosity/blob/e0a698676d19307a095cd4ac1991c4e4e70e56fb/run.py#L178
+    lr: 1e-4 # from large-scale-curiosity
     betas: [0.9, 0.999]
 
 forward_dynamics:
-  _target_:
+  _target_: src.models.forward_dynamics_lit_module.ForwardDynamicsLitModule
   _partial_: true
+  forward_dynamics_net:
+    _target_: src.models.components.forward_dynamics.dense_net_forward_dynamics.DenseNetForwardDynamics
+    dim_action: ${...inverse_dynamics.inverse_dynamics_net.action_predictor.dim_action}
+    dim_embed: ${...inverse_dynamics.inverse_dynamics_net.observation_encoder.dim_out}
+
+  optimizer:
+    _target_: torch.optim.Adam
+    _partial_: true
+    lr: 1e-4 # from large-scale-curiosity
+    betas: [0.9, 0.999]
 
 ppo:
-  _target_:
+  _target_: src.models.ppo_lit_module.PPOLitModule
+
+  net:
+    _target_: src.models.components.policy_value_common_net.PolicyValueCommonNet
+
+    base_model:
+      _target_: src.models.components.small_conv_net.SmallConvNet
+      height: 256 #${environment.sensor.height}
+      width: 256 #${environment.sensor.width}
+      channels: 3
+      dim_out: 1024
+
+    policy:
+      _target_: src.models.components.policy.tanh_normal_stochastic_policy.TanhNormalStochasticPolicy
+      dim_input: ${..base_model.dim_out}
+      dim_out: ${....inverse_dynamics.inverse_dynamics_net.action_predictor.dim_action}
+
+    value:
+      _target_: src.models.components.value.fully_connect_value.FullyConnectValue
+      dim_input: ${..base_model.dim_out}
+
+  optimizer:
+    _target_: torch.optim.Adam
+    _partial_: true
+    lr: 1e-4 # from large-scale-curiosity
+    betas: [0.9, 0.999]

--- a/configs/model/inverse_forward_ppo.yaml
+++ b/configs/model/inverse_forward_ppo.yaml
@@ -8,8 +8,8 @@ inverse_dynamics:
 
     observation_encoder:
       _target_: src.models.components.small_conv_net.SmallConvNet
-      height: 256 #${environment.sensor.height}
-      width: 256 #${environment.sensor.width}
+      height: ${environment.sensor.height}
+      width: ${environment.sensor.width}
       channels: 3
       dim_out: 1024
 
@@ -46,8 +46,8 @@ ppo:
 
     base_model:
       _target_: src.models.components.small_conv_net.SmallConvNet
-      height: 256 #${environment.sensor.height}
-      width: 256 #${environment.sensor.width}
+      height: ${environment.sensor.height}
+      width: ${environment.sensor.width}
       channels: 3
       dim_out: 1024
 

--- a/configs/model/inverse_forward_ppo.yaml
+++ b/configs/model/inverse_forward_ppo.yaml
@@ -1,0 +1,32 @@
+_target_: src.models.aggregations.inverse_forward_ppo.InverseForwardPPO
+
+inverse_dynamics:
+  _target_: src.models.inverse_dynamics_lit_module.InverseDynamicsLitModule
+
+  inverse_dynamics_net:
+    _target_: src.models.components.inverse_dynamics.inverse_dynamics.InverseDynamics
+
+    observation_encoder:
+      _target_: src.models.components.small_conv_net.SmallConvNet
+      height: 256 #${environment.sensor.height}
+      width: 256 #${environment.sensor.width}
+      channels: 3
+      dim_out: 1024
+
+    action_predictor:
+      _target_: src.models.components.action_predictor.continuous_action_predictor.ContinuousActionPredictor
+      dim_embed: ${..observation_encoder.dim_out}
+      dim_action: 3
+
+  optimizer:
+    _target_: torch.optim.Adam
+    _partial_: true
+    lr: 1e-4 # https://github.com/openai/large-scale-curiosity/blob/e0a698676d19307a095cd4ac1991c4e4e70e56fb/run.py#L178
+    betas: [0.9, 0.999]
+
+forward_dynamics:
+  _target_:
+  _partial_: true
+
+ppo:
+  _target_:

--- a/configs/paths/default.yaml
+++ b/configs/paths/default.yaml
@@ -1,0 +1,18 @@
+# path to root directory
+# this requires PROJECT_ROOT environment variable to exist
+# you can replace it with "." if you want the root to be the current working directory
+root_dir: ${oc.env:PROJECT_ROOT}
+
+# path to data directory
+data_dir: ${paths.root_dir}/data/
+
+# path to logging directory
+log_dir: ${paths.root_dir}/logs/
+
+# path to output directory, created dynamically by hydra
+# path generation pattern is specified in `configs/hydra/default.yaml`
+# use it to store all files generated during the run, like ckpts and metrics
+output_dir: ${hydra:runtime.output_dir}
+
+# path to working directory
+work_dir: ${hydra:runtime.cwd}

--- a/configs/trainers_builder/inverse_forward_ppo.yaml
+++ b/configs/trainers_builder/inverse_forward_ppo.yaml
@@ -1,0 +1,55 @@
+_target_: src.trainers.builders.inverse_forward_ppo.InverseForwardPPO
+
+inverse_dynamics:
+  _target_: src.trainers.inverse_dynamics_trainer.InverseDynamicsTrainer
+  _partial_: true
+
+  dataloader:
+    _target_: torch.utils.data.DataLoader
+    _partial_: true
+    batch_size: 8 # from large-scale-curiosity run.py#L175
+    shuffle: true
+
+  pl_trainer:
+    _target_: lightning.pytorch.Trainer
+    default_root_dir: ${paths.output_dir}/inverse_dynamics
+    max_epochs: 3 # from large-scale-curiosity run.py#L180
+    accelerator: gpu
+    devices: 1
+    deterministic: False
+
+forward_dynamics:
+  _target_: src.trainers.forward_dynamics_trainer.ForwardDynamicsTrainer
+  _partial_: true
+
+  dataloader:
+    _target_: torch.utils.data.DataLoader
+    _partial_: true
+    batch_size: 8 # from large-scale-curiosity run.py#L175
+    shuffle: true
+
+  pl_trainer:
+    _target_: lightning.pytorch.Trainer
+    default_root_dir: ${paths.output_dir}/forward_dynamics
+    max_epochs: 3 # from large-scale-curiosity run.py#L180
+    accelerator: gpu
+    devices: 1
+    deterministic: False
+
+ppo:
+  _target_: src.trainers.ppo_trainer.PPOTrainer
+  _partial_: true
+
+  dataloader:
+    _target_: torch.utils.data.DataLoader
+    _partial_: true
+    batch_size: 8 # from large-scale-curiosity run.py#L175
+    shuffle: true
+
+  pl_trainer:
+    _target_: lightning.pytorch.Trainer
+    default_root_dir: ${paths.output_dir}/ppo
+    max_epochs: 3 # from large-scale-curiosity run.py#L180
+    accelerator: gpu
+    devices: 1
+    deterministic: False

--- a/demos/demo_agent_learning.py
+++ b/demos/demo_agent_learning.py
@@ -10,6 +10,7 @@ from src.environment.environment import Environment
 from src.interactions.interaction import Interaction
 from src.models.aggregations.neural_networks import NeuralNetworks
 from src.trainers.builders.trainers_builder import TrainersBuilder
+from src.trainers.trainer import Trainer
 from src.utils.random import seed_everything
 
 rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
@@ -45,6 +46,29 @@ def main(cfg: DictConfig) -> None:
     logger.info(f"Instantiating interaction<{cfg.interaction._target_}>")
     interaction: Interaction = hydra.utils.instantiate(cfg.interaction)
     interaction = interaction(agent=agent, environment=environment)
+
+    loop(interaction, trainer)
+
+    logger.info("End demo.")
+
+
+def loop(interaction: Interaction, trainer: Trainer) -> None:
+    """main loop process."""
+    logger.info("Start main loop.")
+
+    try:
+        while True:
+            logger.info("Interacting...")
+            interaction.interact()
+            logger.info("End iteraction.")
+
+            logger.info("Training...")
+            trainer.train()
+            logger.info("End training.")
+    except KeyboardInterrupt:
+        logger.error("Keyboard interrupted.")
+    finally:
+        logger.info("End main loop.")
 
 
 if __name__ == "__main__":

--- a/demos/demo_agent_learning.py
+++ b/demos/demo_agent_learning.py
@@ -1,0 +1,51 @@
+import logging
+
+import hydra
+import rootutils
+from omegaconf import DictConfig
+
+from src.agents.agent import Agent
+from src.data_collectors.data_collector import DataCollector
+from src.environment.environment import Environment
+from src.interactions.interaction import Interaction
+from src.models.aggregations.neural_networks import NeuralNetworks
+from src.trainers.builders.trainers_builder import TrainersBuilder
+from src.utils.random import seed_everything
+
+rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
+
+logger = logging.getLogger(__name__)
+
+
+@hydra.main("../configs", config_name="demo.yaml", version_base="1.3")
+def main(cfg: DictConfig) -> None:
+    logger.info("Demo start!")
+
+    if cfg.get("seed") is not None:
+        seed_everything(cfg.seed)
+        logger.info(f"Set seed to {cfg.seed}")
+
+    logger.info(f"Instantiating model: <{cfg.model._target_}>")
+    model: NeuralNetworks = hydra.utils.instantiate(cfg.model)
+
+    logger.info(f"Instantiating data collector: <{cfg.data_collector._target_}>")
+    data_collector: DataCollector = hydra.utils.instantiate(cfg.data_collector)
+
+    logger.info(f"Instantiating trainers builder: <{cfg.trainers_builder._target_}>")
+    trainers_builder: TrainersBuilder = hydra.utils.instantiate(cfg.trainers_builder)
+    trainer = trainers_builder.build(model, data_collector)
+
+    logger.info(f"Instantiating agent: <{cfg.agent._target_}>")
+    agent: Agent = hydra.utils.instantiate(cfg.agent)
+    agent = agent(**model.build_agent_models(), data_collector=data_collector)
+
+    logger.info(f"Instantiating environment: <{cfg.environment._target_}>")
+    environment: Environment = hydra.utils.instantiate(cfg.environment)
+
+    logger.info(f"Instantiating interaction<{cfg.interaction._target_}>")
+    interaction: Interaction = hydra.utils.instantiate(cfg.interaction)
+    interaction = interaction(agent=agent, environment=environment)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ vrchat-io = {git = "https://github.com/Geson-anko/vrchat-io.git", rev = "main"}
 lightning = "^2.0.8"
 hydra-core = "^1.3.2"
 rootutils = "^1.0.7"
+hydra-colorlog = "^1.2.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ torchrl = "^0.1.1"
 vrchat-io = {git = "https://github.com/Geson-anko/vrchat-io.git", rev = "main"}
 lightning = "^2.0.8"
 hydra-core = "^1.3.2"
+rootutils = "^1.0.7"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ torch = ">=2.0.0 !=2.0.1"
 torchrl = "^0.1.1"
 vrchat-io = {git = "https://github.com/Geson-anko/vrchat-io.git", rev = "main"}
 lightning = "^2.0.8"
+hydra-core = "^1.3.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"

--- a/src/trainers/ppo_trainer.py
+++ b/src/trainers/ppo_trainer.py
@@ -14,15 +14,15 @@ class PPOTrainer(Trainer):
         module: PPOLitModule,
         data_collector: TrajectoryDataCollector,
         dataloader: partial[DataLoader],
-        trainer: pl.Trainer,
+        pl_trainer: pl.Trainer,
     ):
         self.module = module
         self.data_collector = data_collector
         self.dataloader = dataloader
-        self.trainer = trainer
+        self.pl_trainer = pl_trainer
 
     def train(self):
         dataset = self.data_collector.get_data()
         dataloader = self.dataloader(dataset=dataset)
-        self.trainer.fit(self.module, dataloader)
+        self.pl_trainer.fit(self.module, dataloader)
         self.data_collector.clear()

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -1,0 +1,3 @@
+import rootutils
+
+PROJECT_ROOT = rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)

--- a/tests/config_tests/test_agent.py
+++ b/tests/config_tests/test_agent.py
@@ -1,5 +1,5 @@
 import hydra
-from omegaconf import OmegaConf, open_dict
+from omegaconf import OmegaConf
 
 from src.utils.paths import PROJECT_ROOT
 

--- a/tests/config_tests/test_agent.py
+++ b/tests/config_tests/test_agent.py
@@ -1,0 +1,9 @@
+import hydra
+from omegaconf import OmegaConf, open_dict
+
+from src.utils.paths import PROJECT_ROOT
+
+
+def test_curiosity_ppo_agent():
+    cfg = OmegaConf.load(PROJECT_ROOT / "configs/agent/curiosity_ppo_agent.yaml")
+    hydra.utils.instantiate(cfg)

--- a/tests/config_tests/test_data_collector.py
+++ b/tests/config_tests/test_data_collector.py
@@ -1,0 +1,12 @@
+import hydra
+from omegaconf import OmegaConf, open_dict
+
+from src.utils.paths import PROJECT_ROOT
+
+
+def test_dict_dynamics_trajectory():
+    cfg = OmegaConf.load(PROJECT_ROOT / "configs/data_collector/dict_dynamics_trajectory.yaml")
+    with open_dict(cfg):
+        cfg.trajectory.max_size = 128
+
+    hydra.utils.instantiate(cfg)

--- a/tests/config_tests/test_environment.py
+++ b/tests/config_tests/test_environment.py
@@ -1,0 +1,11 @@
+import hydra
+from omegaconf import OmegaConf
+from pytest_mock import MockerFixture
+
+from src.utils.paths import PROJECT_ROOT
+
+
+def test_frame_locomotion_sleep(mocker: MockerFixture):
+    mocker.patch("cv2.VideoCapture")  # Avoid no camera device error
+    cfg = OmegaConf.load(PROJECT_ROOT / "configs/environment/frame_locomotion_sleep.yaml")
+    hydra.utils.instantiate(cfg)

--- a/tests/config_tests/test_interaction.py
+++ b/tests/config_tests/test_interaction.py
@@ -1,0 +1,9 @@
+import hydra
+from omegaconf import OmegaConf, open_dict
+
+from src.utils.paths import PROJECT_ROOT
+
+
+def test_fixed_step():
+    cfg = OmegaConf.load(PROJECT_ROOT / "configs/interaction/fixed_step.yaml")
+    hydra.utils.instantiate(cfg)

--- a/tests/config_tests/test_model.py
+++ b/tests/config_tests/test_model.py
@@ -1,0 +1,17 @@
+import hydra
+from omegaconf import OmegaConf, open_dict
+
+from src.utils.paths import PROJECT_ROOT
+
+
+def test_inverse_forward_ppo():
+    cfg = OmegaConf.load(PROJECT_ROOT / "configs/model/inverse_forward_ppo.yaml")
+
+    with open_dict(cfg):
+        height, width = 256, 256
+        cfg.inverse_dynamics.inverse_dynamics_net.observation_encoder.height = height
+        cfg.inverse_dynamics.inverse_dynamics_net.observation_encoder.width = width
+        cfg.ppo.net.base_model.height = height
+        cfg.ppo.net.base_model.width = width
+
+    hydra.utils.instantiate(cfg)

--- a/tests/config_tests/test_trainers_builder.py
+++ b/tests/config_tests/test_trainers_builder.py
@@ -11,7 +11,10 @@ def test_inverse_forward_ppo(tmp_path: Path):
 
     with open_dict(cfg):
         cfg.inverse_dynamics.pl_trainer.default_root_dir = str(tmp_path / "inverse_dynamics")
+        cfg.inverse_dynamics.pl_trainer.accelerator = "cpu"
         cfg.forward_dynamics.pl_trainer.default_root_dir = str(tmp_path / "forward_dynamics")
+        cfg.forward_dynamics.pl_trainer.accelerator = "cpu"
         cfg.ppo.pl_trainer.default_root_dir = str(tmp_path / "ppo")
+        cfg.ppo.pl_trainer.accelerator = "cpu"
 
     hydra.utils.instantiate(cfg)

--- a/tests/config_tests/test_trainers_builder.py
+++ b/tests/config_tests/test_trainers_builder.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+import hydra
+from omegaconf import OmegaConf, open_dict
+
+from src.utils.paths import PROJECT_ROOT
+
+
+def test_inverse_forward_ppo(tmp_path: Path):
+    cfg = OmegaConf.load(PROJECT_ROOT / "configs/trainers_builder/inverse_forward_ppo.yaml")
+
+    with open_dict(cfg):
+        cfg.inverse_dynamics.pl_trainer.default_root_dir = str(tmp_path / "inverse_dynamics")
+        cfg.forward_dynamics.pl_trainer.default_root_dir = str(tmp_path / "forward_dynamics")
+        cfg.ppo.pl_trainer.default_root_dir = str(tmp_path / "ppo")
+
+    hydra.utils.instantiate(cfg)

--- a/tests/utils/test_paths.py
+++ b/tests/utils/test_paths.py
@@ -1,0 +1,8 @@
+import os
+from pathlib import Path
+
+from src.utils import paths
+
+
+def test_project_root():
+    assert paths.PROJECT_ROOT == Path(os.path.abspath(__file__)).parent.parent.parent


### PR DESCRIPTION
## 概要

#87 VRChatとインタラクションしながら エージェントが学習するデモスクリプトを作成しました。
変更内容が大規模化してきたのでいくつか既知のバグが存在しますが、プルリクエストを送信します。

主に行ったこと
1. コンポーネントクラスを呼び出すための設定ファイルの作成とテスト
2. 学習デモの基本処理

## バグ・未実装機能

### パラメータファイルの読み込み

パラメータは PyTorch lightning のTrainerによって自動的に保存されますが、それを読み込んで実行する方法を実装していません。
現在は、`LightningModule.load_from_checkpoint` クラスメソッドから呼び出す方法を検討しています。また、`pl.Trainer`はfit時にcheckpointを指定することによって、optimizerやschedulerの状態を読み込むため、その処理も実装する必要があります。
https://lightning.ai/docs/pytorch/stable/common/checkpointing_basic.html

#### NOTE: 保存について
複数のモデルやTrainerが存在するため、パラメータファイルを一つにまとめて保存する方式を取ることは避けたいと考えています。その方がモジュール性が向上し、一部だけ学習済みモデルを用いるといったことが可能になります。

また、現在のLightning Trainerの保存方式では、無限にモデルファイルが保存されていってしまう問題があり、最大ファイル数を定めて古いものを消す処理を実装する必要があります。`ModelCheckpoint` コールバックを継承して、`_save_checkpoint`メソッドをラップすることで実現するアイデアがあります。
```py
    def _save_checkpoint(self, trainer: "pl.Trainer", filepath: str) -> None:
        trainer.save_checkpoint(filepath, self.save_weights_only)
```
https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.ModelCheckpoint.html

### デモ終了時にOSCのリセットが送信されない

これは静止命令がVRChatに送信されていないことが原因です。  
解決策としては、`Environment`, `Actuator`, `Sensor` といったクラスに`teardown`メソッドを実装し、インタラクション終了時に確実に呼び出すことが求められます。

今回のバグを修正するためには、 `Actuator`クラスに`teardown`メソッドを実装し、静止命令を呼び出す必要があります。

### Trainerを再利用できない
学習を終えた`Trainer`は、そのままもう一度 `fit`を呼び出しても学習してくれないようです。
```
[2023-09-25 14:12:51,368][lightning.pytorch.utilities.rank_zero][INFO] - `Trainer.fit` stopped: `max_epochs=3` reached.
```

### PPOPolicyの構造を論文と合わせていない

#97 の変更内容を取り込むためには、 #100 が必要です。


## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make test`コマンドでローカルにテストしましたか?
- [x] `make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
