### PR TITLE
SensorとActuatorクラスにsetupとteardownメソッドを追加し、#101のバグを修正

### DIFF
--- a/demos/demo_agent_interaction.py
+++ b/demos/demo_agent_interaction.py
@@ -67,7 +67,7 @@ def main():
     except Exception as e:
         logger.exception(e)
     finally:
-        environment.actuator.operate(agent._postprocess_action(agent.sleep_action))
+        environment.teardown()
 
     logger.info("End agent interaction demo.")
 

--- a/demos/demo_agent_learning.py
+++ b/demos/demo_agent_learning.py
@@ -49,6 +49,8 @@ def main(cfg: DictConfig) -> None:
 
     loop(interaction, trainer)
 
+    environment.teardown()
+
     logger.info("End demo.")
 
 

--- a/src/environment/actuators/actuator.py
+++ b/src/environment/actuators/actuator.py
@@ -6,3 +6,11 @@ class Actuator(metaclass=ABCMeta):
     @abstractmethod
     def operate(action: Any) -> None:
         raise NotImplementedError
+
+    def setup(self):
+        """Called at the start of interaction with the agent."""
+        pass
+
+    def teardown(self):
+        """Called at the end of interaction with the agent."""
+        pass

--- a/src/environment/actuators/locomotion_actuator.py
+++ b/src/environment/actuators/locomotion_actuator.py
@@ -15,6 +15,9 @@ class LocomotionActuator(Actuator):
         _action = action.detach().cpu().numpy().tolist()
         self.actuator.command(_action[0], _action[1], _action[2])
 
+    def teardown(self):
+        return self.operate(get_sleep_action())
+
 
 def get_sleep_action() -> torch.Tensor:
     """Return sleep action for LocomotionActuator.

--- a/src/environment/periodic_environment.py
+++ b/src/environment/periodic_environment.py
@@ -13,6 +13,8 @@ class PeriodicEnvironment(Environment):
         self.adjustor = adjustor
 
     def setup(self):
+        self.sensor.setup()
+        self.actuator.setup()
         self.reset_interval_start_time()
 
     def observe(self) -> torch.Tensor:
@@ -29,4 +31,6 @@ class PeriodicEnvironment(Environment):
         return self.adjustor.adjust()
 
     def teardown(self) -> None:
-        return
+        self.sensor.teardown()
+        self.actuator.teardown()
+        

--- a/src/environment/periodic_environment.py
+++ b/src/environment/periodic_environment.py
@@ -33,4 +33,3 @@ class PeriodicEnvironment(Environment):
     def teardown(self) -> None:
         self.sensor.teardown()
         self.actuator.teardown()
-        

--- a/src/environment/sensors/sensor.py
+++ b/src/environment/sensors/sensor.py
@@ -6,3 +6,11 @@ class Sensor(metaclass=ABCMeta):
     def read(self):
         """Read and return data from the actual sensor."""
         raise NotImplementedError
+
+    def setup(self):
+        """Called at the start of interaction with the agent."""
+        pass
+
+    def teardown(self):
+        """Called at the end of interaction with the agent."""
+        pass

--- a/tests/environment/actuators/test_locomotion_actuator.py
+++ b/tests/environment/actuators/test_locomotion_actuator.py
@@ -34,6 +34,10 @@ class TestLocomotionWrapper:
         action = torch.tensor([0.0, 0.0, 0.0], device="cuda")
         self._test_operate(axes_actuator, action)
 
+    def test_teardown(self, axes_actuator):
+        mod = LocomotionActuator(axes_actuator)
+        mod.teardown()
+
 
 def test_sleep_action():
     assert torch.equal(get_sleep_action(), torch.zeros(3))


### PR DESCRIPTION
## 概要

#101 で報告された、デモ終了時にVRChat上でずっとAMIが動き続けてしまう問題を解決しました。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make test`コマンドでローカルにテストしましたか?
- [x] `make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
