### PR TITLE
tensordictのバージョンが0.2.0以降だとtorchrlが動かないので修正

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ hydra-core = "^1.3.2"
 rootutils = "^1.0.7"
 hydra-colorlog = "^1.2.0"
 tensorboard = "^2.14.1"
+tensordict = "<0.2.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
## 概要

次のimportが動かないので tensordict 0.2.0以前を使うようにpyproject.tomlに依存関係の記述を追加しました。
```
from tensordict.nn.common import _seq_of_nested_key_check
```


## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make test`コマンドでローカルにテストしましたか?
- [x] `make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
