### PR TITLE
SConvの隠れ状態を出力する

### DIFF
--- a/src/models/components/forward_dynamics/spiral_conv_forward_dynamics.py
+++ b/src/models/components/forward_dynamics/spiral_conv_forward_dynamics.py
@@ -17,7 +17,7 @@ class SpiralConvForwardDynamics(TimeSeriesForwardDynamics):
     def forward(self, prev_action: Tensor, embed: Tensor, action: Tensor) -> Tensor:
         x = torch.concat([embed, action], dim=-1).unsqueeze(0)
         x = self.fc_in(x)
-        x = self.spiral_conv(x)
+        x, _ = self.spiral_conv(x)
         x = self.fc_out(x)
         return x.squeeze(0)
 

--- a/src/models/components/spiral_conv.py
+++ b/src/models/components/spiral_conv.py
@@ -27,8 +27,8 @@ class SpiralConv(nn.Module):
         self.phazor_init = nn.Parameter(torch.randn(dim, dtype=torch.cfloat))  # log(-log(gamma))
         self.phazor = nn.Parameter(torch.exp(2.0j * np.pi * torch.arange(dim) / dim) * torch.abs(torch.randn(dim)))
 
-    # (batch, len, dim) -> (batch, len, dim)
-    def forward(self, x: Tensor, hidden: Tensor) -> Tensor:
+    # ((batch, len, dim),(batch, dim)) -> ((batch, len, dim), (batch, len, dim))
+    def forward(self, x: Tensor, hidden: Tensor) -> tuple[Tensor, Tensor]:
         batch = x.shape[0]
         len = x.shape[1]
         phazor = self.phazor / self.phazor.abs() * torch.exp(-self.phazor.abs())
@@ -43,7 +43,7 @@ class SpiralConv(nn.Module):
             0
         ) * phazor.unsqueeze(0).unsqueeze(0)
 
-        return conv_with_past.real, conv_with_past[:, -1, :]
+        return conv_with_past.real, conv_with_past
 
 
 class ArchitectureBlock(nn.Module):
@@ -56,7 +56,7 @@ class ArchitectureBlock(nn.Module):
         self.fc = nn.Linear(dim, dim)
         self.dropout = nn.Dropout(dropout)
 
-    def forward(self, x: Tensor, hidden: Tensor) -> Tensor:
+    def forward(self, x: Tensor, hidden: Tensor) -> tuple[Tensor, Tensor]:
         x_ = x
         y = x
         x = self.layer_norm(x)

--- a/src/models/components/spiral_conv.py
+++ b/src/models/components/spiral_conv.py
@@ -3,20 +3,20 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 
+from .stacked_hidden_state import StackedHiddenState
+
 
 class FFN(nn.Module):
-    def __init__(self, dim: int, dim_ff_scale: float, dropout: float):
+    def __init__(self, dim: int, dim_ff_scale: float):
         super().__init__()
         self.linear_1 = nn.Linear(dim, dim * dim_ff_scale, bias=True)
         self.linear_2 = nn.Linear(dim * dim_ff_scale, dim, bias=True)
         self.act = nn.SiLU()
-        self.dropout = nn.Dropout(dropout)
 
     def forward(self, x: Tensor) -> Tensor:
         x = self.linear_1(x)
         x = self.act(x)
         x = self.linear_2(x)
-        x = self.dropout(x)
         return x
 
 
@@ -26,16 +26,11 @@ class SpiralConv(nn.Module):
         self.dim = dim
         self.phazor_init = nn.Parameter(torch.randn(dim, dtype=torch.cfloat))  # log(-log(gamma))
         self.phazor = nn.Parameter(torch.exp(2.0j * np.pi * torch.arange(dim) / dim) * torch.abs(torch.randn(dim)))
-        self.last_conv = None  # (batch, dim)
-        self.last_conv_init = nn.Parameter(torch.randn(dim, dtype=torch.cfloat))  # (dim)
-        self.is_refresh = True
 
     # (batch, len, dim) -> (batch, len, dim)
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(self, x: Tensor, hidden: Tensor) -> Tensor:
         batch = x.shape[0]
         len = x.shape[1]
-        if self.last_conv is None:
-            self.last_conv = self.last_conv_init.expand(batch, self.dim)
         phazor = self.phazor / self.phazor.abs() * torch.exp(-self.phazor.abs())
         phazor_progression = torch.pow(
             phazor.unsqueeze(0), torch.arange(len, device=x.device).unsqueeze(1)
@@ -44,42 +39,28 @@ class SpiralConv(nn.Module):
         filter_fft = torch.fft.fft(filter, n=len * 2, dim=0)  # (len*2, dim)
         x_fft = torch.fft.fft(x, n=len * 2, dim=1)  # (batch, len*2, dim)
         conv_filter_x = torch.fft.ifft(filter_fft.unsqueeze(0) * x_fft, dim=1).narrow(1, 0, len)  # (batch, len, dim)
-        conv_with_past = conv_filter_x + self.last_conv.detach().unsqueeze(1) * phazor_progression.unsqueeze(
+        conv_with_past = conv_filter_x + hidden.detach().unsqueeze(1) * phazor_progression.unsqueeze(
             0
         ) * phazor.unsqueeze(0).unsqueeze(0)
-        if self.is_refresh:
-            self.last_conv = conv_with_past[:, -1, :]
 
-        return conv_with_past.real
-
-    def reset_hidden(self):
-        self.last_conv = None
-
-    def set_is_refresh(self, is_refresh: bool):
-        self.is_refresh = is_refresh
-
-    def get_hidden(self) -> Tensor:
-        return self.last_conv
-
-    def set_hidden(self, hidden: Tensor):
-        self.last_conv = hidden
+        return conv_with_past.real, conv_with_past[:, -1, :]
 
 
 class ArchitectureBlock(nn.Module):
     def __init__(self, dim: int, dim_ff_scale: float, dropout: float):
         super().__init__()
         self.spiral_conv = SpiralConv(dim)
-        self.ffn = FFN(dim, dim_ff_scale, dropout)
+        self.ffn = FFN(dim, dim_ff_scale)
         self.layer_norm = nn.LayerNorm(dim)
         self.silu = nn.SiLU()
         self.fc = nn.Linear(dim, dim)
         self.dropout = nn.Dropout(dropout)
 
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(self, x: Tensor, hidden: Tensor) -> Tensor:
         x_ = x
         y = x
         x = self.layer_norm(x)
-        x = self.spiral_conv(x)
+        x, hidden = self.spiral_conv(x, hidden)
         y = self.fc(y)
         y = self.silu(y)
         x = x * y
@@ -89,47 +70,15 @@ class ArchitectureBlock(nn.Module):
         x_ = x
         x = self.layer_norm(x)
         x = self.ffn(x)
+        x = self.dropout(x)
         x = x + x_
 
-        return x
-
-    def reset_hidden(self):
-        self.spiral_conv.reset_hidden()
-
-    def set_is_refresh(self, is_refresh: bool):
-        self.spiral_conv.set_is_refresh(is_refresh)
-
-    def get_hidden(self) -> Tensor:
-        return self.spiral_conv.get_hidden()
-
-    def set_hidden(self, hidden: Tensor):
-        self.spiral_conv.set_hidden(hidden)
+        return x, hidden
 
 
-class Architecture(nn.Module):
+class Architecture(StackedHiddenState):
     def __init__(self, depth: int, dim: int, dim_ff_scale: float, dropout: float):
-        super().__init__()
-        self.block_list = nn.ModuleList([ArchitectureBlock(dim, dim_ff_scale, dropout) for _ in range(depth)])
-
-    def forward(self, x: Tensor) -> Tensor:
-        for block in self.block_list:
-            x = block(x)
-        return x
-
-    def reset_hidden(self):
-        for block in self.block_list:
-            block.reset_hidden()
-
-    def set_is_refresh(self, is_refresh: bool):
-        for block in self.block_list:
-            block.set_is_refresh(is_refresh)
-
-    def get_hidden(self) -> list[tuple[Tensor, Tensor]]:
-        hidden_list = []
-        for block in self.block_list:
-            hidden_list.append(block.get_hidden())
-        return hidden_list
-
-    def set_hidden(self, hidden_list):
-        for i, block in enumerate(self.block_list):
-            block.set_hidden(hidden_list[i])
+        super().__init__(
+            nn.ModuleList([ArchitectureBlock(dim, dim_ff_scale, dropout) for _ in range(depth)]),
+            [nn.Parameter(torch.randn(dim, dtype=torch.cfloat)) for _ in range(depth)],
+        )

--- a/src/models/components/spiral_conv.py
+++ b/src/models/components/spiral_conv.py
@@ -31,7 +31,8 @@ class SpiralConv(nn.Module):
     def forward(self, x: Tensor, hidden: Tensor) -> tuple[Tensor, Tensor]:
         batch = x.shape[0]
         len = x.shape[1]
-        phazor = self.phazor / self.phazor.abs() * torch.exp(-self.phazor.abs())
+        phazor = self.phazor
+        phazor = torch.exp(-phazor.real * phazor.real - phazor.imag * phazor.imag) * torch.exp(1.0j * phazor.angle())
         phazor_progression = torch.pow(
             phazor.unsqueeze(0), torch.arange(len, device=x.device).unsqueeze(1)
         )  # (len, dim)

--- a/src/models/components/stacked_hidden_state.py
+++ b/src/models/components/stacked_hidden_state.py
@@ -11,7 +11,7 @@ class HiddenState(nn.Module):
 
     def forward(self, x: Tensor):
         if self.hidden is None:
-            self.hidden = self.hidden_init
+            self.hidden = self.hidden_init.unsqueeze(0).expand(x.shape[0], -1)
 
         x, hidden = self.module(x, self.hidden)
         self.hidden = hidden
@@ -28,7 +28,8 @@ class HiddenState(nn.Module):
 
 
 class StackedHiddenState(nn.Module):
-    def __init__(self, module_list: [nn.Module], hidden_init_list: [Tensor]):
+    def __init__(self, module_list: nn.ModuleList, hidden_init_list: [Tensor]):
+        super().__init__()
         self.module_list = nn.ModuleList(
             [HiddenState(module_list[i], hidden_init_list[i]) for i in range(len(module_list))]
         )

--- a/src/models/components/stacked_hidden_state.py
+++ b/src/models/components/stacked_hidden_state.py
@@ -14,8 +14,8 @@ class HiddenState(nn.Module):
             self.hidden = self.hidden_init.unsqueeze(0).expand(x.shape[0], -1)
 
         x, hidden = self.module(x, self.hidden)
-        self.hidden = hidden
-        return x
+        self.hidden = hidden[:, -1, :]
+        return x, hidden
 
     def reset_hidden(self):
         self.hidden = None
@@ -28,24 +28,26 @@ class HiddenState(nn.Module):
 
 
 class StackedHiddenState(nn.Module):
-    def __init__(self, module_list: nn.ModuleList, hidden_init_list: [Tensor]):
+    def __init__(self, module_list: nn.ModuleList, hidden_init_list: list[Tensor]):
         super().__init__()
         self.module_list = nn.ModuleList(
             [HiddenState(module_list[i], hidden_init_list[i]) for i in range(len(module_list))]
         )
 
-    def forward(self, x: Tensor):
+    def forward(self, x: Tensor) -> tuple[Tensor, list[Tensor]]:
+        hidden_list = []
         for module in self.module_list:
-            x = module(x)
-        return x
+            x, hidden = module(x)
+            hidden_list.append(hidden)
+        return x, hidden_list
 
     def reset_hidden(self):
         for module in self.module_list:
             module.reset_hidden()
 
-    def get_hidden(self):
+    def get_hidden(self) -> list[Tensor]:
         return [module.get_hidden() for module in self.module_list]
 
-    def set_hidden(self, hidden_list: [Tensor]):
+    def set_hidden(self, hidden_list: list[Tensor]):
         for i, module in enumerate(self.module_list):
             module.set_hidden(hidden_list[i])

--- a/src/models/components/stacked_hidden_state.py
+++ b/src/models/components/stacked_hidden_state.py
@@ -3,7 +3,7 @@ from torch import Tensor
 
 
 class HiddenState(nn.Module):
-    def __init__(self, module: nn.Module, hidden_init: Tensor):
+    def __init__(self, module: nn.Module, hidden_init: nn.Parameter):
         super().__init__()
         self.module = module
         self.hidden = None
@@ -28,7 +28,7 @@ class HiddenState(nn.Module):
 
 
 class StackedHiddenState(nn.Module):
-    def __init__(self, module_list: nn.ModuleList, hidden_init_list: list[Tensor]):
+    def __init__(self, module_list: nn.ModuleList, hidden_init_list: list[nn.Parameter]):
         super().__init__()
         self.module_list = nn.ModuleList(
             [HiddenState(module_list[i], hidden_init_list[i]) for i in range(len(module_list))]

--- a/src/models/components/stacked_hidden_state.py
+++ b/src/models/components/stacked_hidden_state.py
@@ -1,0 +1,50 @@
+import torch.nn as nn
+from torch import Tensor
+
+
+class HiddenState(nn.Module):
+    def __init__(self, module: nn.Module, hidden_init: Tensor):
+        super().__init__()
+        self.module = module
+        self.hidden = None
+        self.hidden_init = hidden_init
+
+    def forward(self, x: Tensor):
+        if self.hidden is None:
+            self.hidden = self.hidden_init
+
+        x, hidden = self.module(x, self.hidden)
+        self.hidden = hidden
+        return x
+
+    def reset_hidden(self):
+        self.hidden = None
+
+    def get_hidden(self):
+        return self.hidden
+
+    def set_hidden(self, hidden: Tensor):
+        self.last_conv = hidden
+
+
+class StackedHiddenState(nn.Module):
+    def __init__(self, module_list: [nn.Module], hidden_init_list: [Tensor]):
+        self.module_list = nn.ModuleList(
+            [HiddenState(module_list[i], hidden_init_list[i]) for i in range(len(module_list))]
+        )
+
+    def forward(self, x: Tensor):
+        for module in self.module_list:
+            x = module(x)
+        return x
+
+    def reset_hidden(self):
+        for module in self.module_list:
+            module.reset_hidden()
+
+    def get_hidden(self):
+        return [module.get_hidden() for module in self.module_list]
+
+    def set_hidden(self, hidden_list: [Tensor]):
+        for i, module in enumerate(self.module_list):
+            module.set_hidden(hidden_list[i])

--- a/tests/models/components/test_spiral_conv.py
+++ b/tests/models/components/test_spiral_conv.py
@@ -21,5 +21,8 @@ class TestSpiralConv:
     def test_spiral_conv(self, depth, dim, dim_ff_scale, dropout, batch, length):
         model = Architecture(depth, dim, dim_ff_scale, dropout)
         x = torch.randn(batch, length, dim)
-        x = model(x)
+        x, hidden_list = model(x)
         assert x.size() == (batch, length, dim)
+        assert len(hidden_list) == depth
+        for hidden in hidden_list:
+            assert hidden.size() == (batch, length, dim)


### PR DESCRIPTION
## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
https://github.com/MLShukai/PrimitiveAMI/issues/138

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
SConvの入出力に隠れ状態を付加  
一つのブロックは入力x, 隠れ状態h, 出力yとしたとき
`((x_1,x_2,...,x_n),h_0) -> ((y_1,y_2,...,y_n),(h_1,h_2,...,h_n))`
の形の入出力を持つ

## SConvの改良
ArchitectureBlockにおいて
```
---> SConv ---> SiLU ---> SConv --->
```
としていたところを
```
-+----> SConv -----> * --->
 |                   | 
 +-> FC ---> SiLU() -+
```
としている
SConv(x)にSiLU(FC(x))を掛けるGatingは https://hazyresearch.stanford.edu/blog/2023-12-11-zoology2-based を参考にしておりRetNetでも同様の構造がある

また、SConvの振幅の減衰定数を$`exp(-|z|)`$から$`exp(-|z|^2)`$に修正
$`z=0`$付近での定数の変化がゆるやかになる

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make test`コマンドでローカルにテストしましたか?
- [x] `make format`コマンドで `pre-commit` フックを実行しましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
